### PR TITLE
Return None when calling non-process method on parallel subpipeline

### DIFF
--- a/axopy/pipeline/core.py
+++ b/axopy/pipeline/core.py
@@ -149,4 +149,7 @@ class Pipeline(Block):
         for b in block:
             out.append(self._call_block(fname, b, data))
 
-        return out
+        if fname == 'process':
+            return out
+        else:
+            return None

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -236,6 +236,16 @@ def test_clear_pipeline():
     assert b.data == init
 
 
+def test_parallel_clear():
+    # see issue #70
+    p = pipeline.Pipeline([
+        (_FBlock(), _GBlock()),
+        _TwoIn()
+    ])
+    out = p.process(data)
+    p.clear()
+
+
 def test_block_repr():
     b = pipeline.Block()
     assert repr(b) == 'axopy.pipeline.core.Block()'


### PR DESCRIPTION
When calling a non-process method on a parallel sub-pipeline, `[None, None, ...]` was returned, so checking for `data is None` wasn't sufficient for detecting whether or not to pass along a data arg. I think this is the simplest fix.

Fixes #70 