### PR TITLE
Optionally control block shuffle using seed

### DIFF
--- a/axopy/design.py
+++ b/axopy/design.py
@@ -82,7 +82,14 @@ class Block(list):
             Whether or not to set the ``trial`` attribute of each trial such
             that they remain in sequential order after shuffling. This is the
             default.
+
+        seed : int, optional
+            If provided, the random seed will be set to the specified value to
+            ensure reproducible shuffling.
         """
+        if seed is not None:
+            random.seed(seed)
+            
         random.shuffle(self)
         if reset_index:
             for i, trial in enumerate(self):

--- a/axopy/design.py
+++ b/axopy/design.py
@@ -82,10 +82,11 @@ class Block(list):
             Whether or not to set the ``trial`` attribute of each trial such
             that they remain in sequential order after shuffling. This is the
             default.
-
         seed : int, optional
             If provided, the random seed will be set to the specified value to
-            ensure reproducible shuffling.
+            ensure reproducible shuffling. Note that if you have multiple
+            identical blocks and want to shuffle them differently, use a
+            different seed value for each block.
         """
         if seed is not None:
             random.seed(seed)

--- a/axopy/design.py
+++ b/axopy/design.py
@@ -73,7 +73,7 @@ class Block(list):
         self.append(trial)
         return trial
 
-    def shuffle(self, reset_index=True):
+    def shuffle(self, reset_index=True, seed=None):
         """Shuffle the block's trials in random order.
 
         Parameters
@@ -89,7 +89,7 @@ class Block(list):
         """
         if seed is not None:
             random.seed(seed)
-            
+
         random.shuffle(self)
         if reset_index:
             for i, trial in enumerate(self):

--- a/tests/test_design.py
+++ b/tests/test_design.py
@@ -37,3 +37,17 @@ def test_block_shuffle():
     for i in range(10):
         b.shuffle()
         assert b[0].attrs['trial'] == 0
+
+
+def test_block_shuffle_seed():
+    d = design.Design()
+    for i in range(2):
+        b = d.add_block()
+
+        for j in range(10):
+            b.add_trial()
+
+        b.shuffle(reset_index=False, seed=10)
+
+    for j in range(10):
+        assert d[0][j].attrs['trial'] == d[1][j].attrs['trial']


### PR DESCRIPTION
Provide the option to set the random seed to ensure that block shuffling is reproducible.

Useful when trials need to the follow the same order across participants or when multiple conditions are tested for the same participant and stimulus sequence needs to be shared across conditions.

(@ixjlyons  please reject and close PR if you think this is not relevant).